### PR TITLE
Add support for running jobs locally

### DIFF
--- a/batchelor/__init__.py
+++ b/batchelor/__init__.py
@@ -88,11 +88,13 @@ def checkConfig(configFileName, system = ""):
 	                    "gridka": [ "queue", "project", "memory", "header_file" ],
 	                    "lxplus": [ "queue", "pool", "header_file" ],
 	                    "lyon": [],
+	                    "local": [ "shell", "cores" ],
 	                    "simulator": [ "lifetime" ] }
 	filesToTest = { "gridka": [ "header_file" ],
 	                "e18": [ "header_file" ],
 	                "lxplus": [ "header_file" ],
-	                "c2pap": [ "header_file" ] }
+	                "c2pap": [ "header_file" ],
+	                "local": [ "shell" ] }
 	for section in requiredOptions.keys():
 		if config.has_section(section):
 			options = requiredOptions[section]
@@ -157,6 +159,9 @@ class Batchelor:
 			import batchelor._batchelorLxplus as batchFunctions
 		elif self._system == "lyon":
 			import batchelor._batchelorLyon as batchFunctions
+		elif self._system == "local":
+			import batchelor._batchelorLocal as batchFunctions
+			batchFunctions.initialize(self._config)
 		elif self._system == "simulator":
 			import batchelor._batchelorSimulator as batchFunctions
 		else:

--- a/batchelor/_batchelorLocal.py
+++ b/batchelor/_batchelorLocal.py
@@ -1,0 +1,134 @@
+
+import multiprocessing
+import os
+import subprocess
+import tempfile
+
+import batchelor
+
+
+class Job:
+
+	def __init__(self, jobId, command, outputFile, jobName):
+		self.jobId = jobId
+		self.command = command
+		self.outputFile = outputFile
+		self.jobName = jobName
+		self.running = False
+
+
+class Worker(multiprocessing.Process):
+
+	def __init__(self, shell, queue, guard, jobs):
+		multiprocessing.Process.__init__(self)
+		self.shell = shell
+		self.queue = queue
+		self.guard = guard
+		self.jobs = jobs
+
+	def run(self):
+		while True:
+			jobId = self.queue.get()
+			with guard:
+				for i in range(len(self.jobs)):
+					if jobs[i].jobId == jobId:
+						break
+				if jobs[i].jobId != jobId:
+					continue # might actually happen if a
+					         # job is deleted
+				jobs[i].running = True
+				outputFile = jobs[i].outputFile
+				command = jobs[i].command
+			cmdFile = tempfile.NamedTemporaryFile(delete = False)
+			for line in command:
+				cmdFile.write(line)
+			cmdFile.close()
+
+			with open(outputFile, "w") as logFile:
+				subprocess.call([self.shell, cmdFile.name], stdout=logFile, stderr=subprocess.STDOUT)
+
+			os.unlink(cmdFile.name)
+			with guard:
+				for i in range(len(self.jobs)):
+					if jobs[i].jobId == jobId:
+						break
+				if jobs[i].jobId != jobId:
+					raise batchelor.BatchelorException("Job ID {0} finished, but already removed from list of jobs.".format(jobId))
+				del jobs[i]
+			self.queue.task_done()
+
+
+manager = multiprocessing.Manager()
+guard = manager.Lock()
+queue = manager.Queue()
+jobs = manager.list()
+aux = manager.list([0])
+
+
+def initialize(config):
+	cores = int(config.get(submoduleIdentifier(), "cores"))
+	if cores == 0:
+		cores = multiprocessing.cpu_count()
+
+	shell = config.get(submoduleIdentifier(), "shell")
+
+	for i in range(cores):
+		worker = Worker(shell, queue, guard, jobs)
+		worker.start()
+
+
+def submoduleIdentifier():
+	return "local"
+
+
+def submitJob(config, command, outputFile, jobName):
+	with guard:
+		aux[0] += 1
+		jobId = aux[0]
+		jobs.append(Job(jobId, command, outputFile, jobName))
+	queue.put(jobId)
+	return jobId
+
+
+def getListOfActiveJobs(jobName):
+	with guard:
+		return [ job.jobId for job in jobs ]
+
+
+def getNActiveJobs(jobName):
+	with guard:
+		return len(jobs)
+
+
+def jobStillRunning(jobId):
+	with guard:
+		for i in range(len(self.jobs)):
+			if jobs[i].jobId == jobId:
+				return True
+	return False
+
+
+def getListOfErrorJobs(jobName):
+	return []
+
+
+def resetErrorJobs(jobName):
+	return True
+
+
+def deleteErrorJobs(jobName):
+	return True
+
+
+def deleteJobs(jobIds):
+	for jobId in jobIds:
+		with guard:
+			for i in range(len(self.jobs)):
+				if jobs[i].jobId == jobId:
+					break
+			if jobs[i].jobId != jobId:
+				continue
+			if jobs[i].running == True:
+				continue
+			del jobs[i]
+	return True

--- a/example.config
+++ b/example.config
@@ -37,5 +37,10 @@ excluded_hosts = dummy
 
 [lyon]
 
+[local]
+shell = /bin/bash
+# limit the number of cores to be used, 0 means use all (multiprocessing.cpu_count())
+cores = 0
+
 [simulator]
 lifetime = 00:00:30


### PR DESCRIPTION
Add a quick workaround allowing to run jobs locally making use of
multiple cores. One sub-process is spawned for each core to be used
stearing the running of the jobs.

The behaviour can be configured by two options "shell" and "cores".
"shell" defines the shell that is used to process the job commands.
"cores" defines the number of cores that should be occupied in parallel,
if "cores" is 0, all cores available on the system are used.

The following restrictions apply:
- it is not possible to delete running jobs, only those still waiting
  for execution can be removed
- cancelling (e.g. CTRL+C) the main program/script will also cancel the
  sub-processes
- no job tracking across program restarts, non-finished jobs are lost
- in case the program/script finishes normally, the sub-processes are
  not properly terminated
