### PR TITLE
Prevent batchelor from changing arguments.

### DIFF
--- a/batchelor/_batchelorC2PAP.py
+++ b/batchelor/_batchelorC2PAP.py
@@ -69,11 +69,12 @@ def submitJobs(config, newJobs):
 	if len(newJobs) == 0:
 		return []
 
-	for i in range(len(newJobs)):
-		newJobs[i].insert(0, config)
+	poolJobsArgs = []
+	for job in newJobs:
+		poolJobsArgs.append([config] + job)
 
 	pool = multiprocessing.Pool(processes = len(newJobs))
-	jobIds = pool.map(_wrapSubmitJob, newJobs, 1)
+	jobIds = pool.map(_wrapSubmitJob, poolJobsArgs, 1)
 	pool.close()
 	pool.join()
 


### PR DESCRIPTION
In C2PAP's submitJobs function, the list of job arguments which was passed to
it was changed. Prevent this by creating a new list with the altered arguments
instead so that the list given by the user can be recycled.
