### PR TITLE
Implementation of array jobs

### DIFF
--- a/batchelor/__init__.py
+++ b/batchelor/__init__.py
@@ -226,7 +226,7 @@ class Batchelor:
 				jobIds.append(jobId)
 			return jobIds
 
-	def submitArrayJob(self, command, outputFile, arrayStart, arrayEnd, arrayStep, jobName = None):
+	def submitArrayJob(self, command, outputFile, arrayStart, arrayEnd, arrayStep = 1, jobName = None):
 		if not self.initialized():
 			raise BatchelorException("not initialized")
 		try:
@@ -234,7 +234,7 @@ class Batchelor:
 			arrayEnd = int(arrayEnd)
 			arrayStep = int(arrayStep)
 		except ValueError:
-			raise BatchelorException('One of the job array parameters is non-integer')
+			raise BatchelorException('one of the job array parameters is non-integer')
 		if arrayEnd < arrayStart:
 			raise BatchelorException('Last task number in array is bigger than the first')
 		if "submitJob" in self.batchFunctions.__dict__.keys():

--- a/batchelor/_batchelorC2PAP.py
+++ b/batchelor/_batchelorC2PAP.py
@@ -121,9 +121,10 @@ def getListOfActiveJobs(jobName):
 					raise batchelor.BatchelorException("parsing of llq output failed, got job name before job id.")
 				name = line[10:]
 				if name == jobName:
-					jobList.append(currentJobId)
+					jobList.append((currentJobId, -1 ,"dummy"))
 	batchelor.runCommand("rm -f " + fileName)
 	return jobList
+	#example output: [(jobId, 0, "dummy"), ...]
 
 
 def getNActiveJobs(jobName):

--- a/batchelor/_batchelorE18.py
+++ b/batchelor/_batchelorE18.py
@@ -83,6 +83,7 @@ def getListOfActiveJobs(jobName):
 			if jobName is None or job.split()[0] in possibleJobIds:
 				returnList.append( ( int(job.split()[0]), job.split()[-1] if job.split()[-2].isdigit() else '', job.split()[4] ) )
 		return returnList
+		#example output: [(jobId, taskId, jobStatus), ...]
 	except ValueError:
 		raise batchelor.BatchelorException("parsing of qstat output to get job id failed.")
 

--- a/batchelor/_batchelorGridka.py
+++ b/batchelor/_batchelorGridka.py
@@ -70,7 +70,7 @@ def getListOfActiveJobs(jobName):
 			return []
 		jobIdList = stdout.split('\n')
 		possibleJobIds = []
-		for i in range(0,len(jobIdList),2):
+		for i in range(0, len(jobIdList), 2):
 			if jobIdList[i+1].split()[1] != jobName:
 				continue
 			possibleJobIds.append(jobIdList[i].split()[1])
@@ -80,6 +80,7 @@ def getListOfActiveJobs(jobName):
 			if jobName is None or job.split()[0] in possibleJobIds:
 				returnList.append( ( int(job.split()[0]), job.split()[-1] if job.split()[-2].isdigit() else '', job.split()[4] ) )
 		return returnList
+		#example output; [(jobId, taskId, jobStatus), ...]
 	except ValueError:
 		raise batchelor.BatchelorException("parsing of qstat output to get job id failed.")
 

--- a/batchelor/_batchelorLxplus.py
+++ b/batchelor/_batchelorLxplus.py
@@ -63,6 +63,7 @@ def getListOfActiveJobs(jobName):
 	jobList = stdout.split('\n')[1:]
 	try:
 		return [ (int(job.split()[0]), job.split()[-4][job.split()[-4].find("[")+1:-1] if job.split()[-4].find("[") != -1 else '', job.split()[2] ) for job in jobList ]
+		#example output: [(jobId, taskId, jobStatus), ...]
 	except ValueError:
 		raise batchelor.BatchelorException("parsing of bjobs output to get job id failed.")
 


### PR DESCRIPTION
Small improvement over merge request #12 

Finally enable submitting array jobs via the `submitArrayJob` method of `Batchelor`. This method calls the `submitJob` function of the underlying implementation, for the moment this can be done at E18, GridKA and Lxplus. `getListOfActiveJobs` was adjusted to return a list of tuples containing the job and task IDs (and the status), `submitJob` continues to return only the job ID.

Possible issues:
- Tasks at Lxplus mean something entirely different from what they mean at E18 or GridKA.
