### PR TITLE
Changed default queue for GridKa

### DIFF
--- a/example.config
+++ b/example.config
@@ -19,7 +19,7 @@ header_file = ~/analysis/e18Header
 excluded_hosts = dummy
 
 [gridka]
-queue = sl6
+queue = e-long
 project = Compass
 memory = 2G
 header_file = ~/analysis/gridkaHeader


### PR DESCRIPTION
The queue which is working for submitting jobs for COMPASS is e-long.