### PR TITLE
[Batchelorhandler] Fix bug when checking job state

### DIFF
--- a/batchelor/__init__.py
+++ b/batchelor/__init__.py
@@ -498,7 +498,7 @@ class BatchelorHandler(Batchelor):
 			else:
 				with open(log_file) as fin:
 					log_file_content = fin.read();
-					if "BatchelorStatus: ERROR\n" in log_file_content or not "BatchelorStatus: OK\n" in log_file_content:
+					if "BatchelorStatus: ERROR" in log_file_content or not "BatchelorStatus: OK\n" in log_file_content:
 						if verbose:
 							if not error_ids: # first found error
 								print "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"


### PR DESCRIPTION
If an error occurred, the new error message (implemented in a previous commit) has also the exit code, but this was not taken into account in parsing the log-file for the error state