### PR TITLE
Support for Long queue on E18 system

### DIFF
--- a/batchelor/__init__.py
+++ b/batchelor/__init__.py
@@ -105,7 +105,7 @@ def checkConfig(configFileName, system = ""):
 		print("ERROR: System set but corresponding section is missing in config file.")
 		error = True
 	requiredOptions = { "c2pap": [ "group", "notification", "notify_user", "node_usage", "wall_clock_limit", "resources", "job_type", "class" ],
-	                    "e18": [ "shortqueue", "memory", "header_file", "arch" ],
+	                    "e18": [ "queue", "memory", "header_file", "arch" ],
 	                    "gridka": [ "queue", "project", "memory", "header_file" ],
 	                    "lxplus": [ "flavour", "header_file", "memory", "disk" ],
 	                    "lyon": [],
@@ -123,9 +123,15 @@ def checkConfig(configFileName, system = ""):
 			options = requiredOptions[section]
 			for option in options:
 				if not config.has_option(section, option):
-					print("ERROR: '" + section + "' section is missing option '" + option + "'.")
-					error = True
-					continue
+                                        if section is "e18" and option is "queue":
+                                                if not config.has_option("e18", "shortqueue"):
+                                                        print("ERROR: '" + section + "' section is missing option '" + option + "'.")
+                                                        error = True
+                                                        continue
+                                        else:
+                                                print("ERROR: '" + section + "' section is missing option '" + option + "'.")
+                                                error = True
+                                                continue
 				if section in filesToTest.keys() and option in filesToTest[section] and (system == "" or system == section):
 					path = _getRealPath(config.get(section, option))
 					if not os.path.exists(path):

--- a/batchelor/_batchelorE18.py
+++ b/batchelor/_batchelorE18.py
@@ -17,6 +17,14 @@ def submoduleIdentifier():
 
 def submitJob(config, command, outputFile, jobName, wd = None, arrayStart = None, arrayEnd = None, arrayStep = None, priority=None, ompNumThreads=None):
 
+        # Handling for previous queue option
+        queues = {"short" : "short=1 ", "medium" : "medium=1 ", "long" : "long=1"}
+        if config.has_option(submoduleIdentifier(), "queue"):
+                queueOption = "queue"
+        else:
+                queueOption = "shortqueue"
+                queues.update({"1" : "short=1", "true" : "short=1", "0" : "medium=1", "false" : "medium=1"})
+
 	# some checks of the job-settings
 	if wd and os.path.realpath(wd).count(os.path.realpath(os.path.expanduser('~'))):
 		raise batchelor.BatchelorException("The given working-directory is in your home-folder which is no allowed at E18: '{0}'".format(wd))
@@ -43,7 +51,7 @@ def submitJob(config, command, outputFile, jobName, wd = None, arrayStart = None
 		cmnd += "-t " + str(arrayStart) + "-" + str(arrayEnd) + ":" + str(arrayStep) + " "
 	cmnd += "-o '" + outputFile + "' "
 	cmnd += "-wd '" + ("/tmp/" if not wd else wd) + "' "
-	cmnd += "-l short=1 " if config.get(submoduleIdentifier(), "shortqueue") in ["1", "TRUE", "true", "True"] else "-l medium=1 "
+        cmnd += "-l " + queues[config.get(submoduleIdentifier(), queueOption).lower()] + " "
 	cmnd += "-l h_pmem=" + config.get(submoduleIdentifier(), "memory") + " "
 	cmnd += "-l arch=" + config.get(submoduleIdentifier(), "arch") + " "
 	cmnd += _getExcludedHostsString(config)

--- a/example.config
+++ b/example.config
@@ -11,7 +11,7 @@ class = serial
 header_file = ~/analysis/c2papHeader
 
 [e18]
-shortqueue = 1
+queue = short
 arch = lx26-amd64
 memory = 750m
 header_file = ~/analysis/e18Header


### PR DESCRIPTION
The support for setting the queue directly for the E18 batch system
is implemented. The parameter "shortqueue" is changed to "queue" and
the values are now "short" or "Short", "medium" or "Medium", "long"
or "Long".
The default is still the short queue.
This change is breaking! Since the parameter name is changed from
"shortqueue" to "queue" - results into a initialization error in
batchelor.