### PR TITLE
Updates TUM-E18 hostname ending

### DIFF
--- a/batchelor/__init__.py
+++ b/batchelor/__init__.py
@@ -62,7 +62,7 @@ def detectSystem():
 		return "gridka"
 	elif hostname.startswith("lxplus") or hostname.endswith(".cern.ch"):
 		return "lxplusLSF"
-	elif hostname.endswith(".e18.physik.tu-muenchen.de"):
+	elif hostname.endswith(".e18.ph.tum.de"):
 		return "e18"
 	elif hostname.startswith("ccage"):
 		return "lyon"


### PR DESCRIPTION
The hostname ending for the E18 clients at TUM is changed from
e18.physik.tu-muenchen.de to e18.ph.tum.de